### PR TITLE
Add basic generate-passphrase script

### DIFF
--- a/generate-passphrase
+++ b/generate-passphrase
@@ -1,0 +1,6 @@
+#!/bin/sh
+LENGTH=32
+if [ ! -z "$1" ]; then
+  LENGTH=$1
+fi
+cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9!@#$%^&*()_+?><~;' | fold -w $LENGTH | head -n 1

--- a/generate-passphrase
+++ b/generate-passphrase
@@ -3,4 +3,4 @@ LENGTH=32
 if [ ! -z "$1" ]; then
   LENGTH=$1
 fi
-cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9!@#$%^&*()_+?><~;' | fold -w $LENGTH | head -n 1
+cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9!@#\$%^&\*\(\)\+=_' | head -c $LENGTH


### PR DESCRIPTION
This patch adds a script that helps standardize the way passphrases are generated to support the work on 18F/cg-docs#299.