### PR TITLE
Add ignorance to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+credentials.yml
+secrets.yml
+.blobs
+.dev_builds
+.vagrant
+.idea
+.DS_Store
+*.swp
+*~
+*#
+#*
+tmp
+my*.yml
+*-auth


### PR DESCRIPTION
With the work being done in 18F/cg-docs#299 around automating uaac client
authorization creation, the docs suggest creating `*-auth` files to help
with the transfer of credentials after it's created. The project didn't
have any .gitignore values so this patch adds them and helps with the
workflow mentioned above.