### PR TITLE
have the org creation script assign roles to the manager

### DIFF
--- a/cf-create-org.sh
+++ b/cf-create-org.sh
@@ -2,17 +2,18 @@
 
 set -e
 
-if [ "$#" -lt 4 ]; then
-    printf "Usage:\n\n\t./cf-create-org.sh <AGENCY_NAME> <BIZ_ID> <SYSTEM_NAME> <NOTE> <MEMORY>\n\n"
-    exit 1
+if [ "$#" -lt 5 ]; then
+  printf "Usage:\n\n\t./cf-create-org.sh <AGENCY_NAME> <BIZ_ID> <SYSTEM_NAME> <NOTE> <MANAGER> <MEMORY>\n\n"
+  exit 1
 fi
 
 AGENCY_NAME=$1
 BIZ_ID=$2
 SYSTEM_NAME=$3
 NOTE=$4
+MANAGER=$5
 
-MEMORY="${5:-4G}"
+MEMORY="${6:-4G}"
 
 QUOTA_NAME="${AGENCY_NAME}_${BIZ_ID}_${NOTE}"
 ORG_NAME="${AGENCY_NAME}-${SYSTEM_NAME}"
@@ -22,10 +23,23 @@ NUMBER_OF_SERVICES=10
 # Step 1: Create the quota
 cf create-quota "$QUOTA_NAME" -m "$MEMORY" -r "$NUMBER_OF_ROUTES" -s "$NUMBER_OF_SERVICES" --allow-paid-service-plans
 
+ADMIN=$(cf target | grep -i user | awk '{print $2}')
+
 # Step 2: Create the org
 cf create-org "$ORG_NAME" -q "$QUOTA_NAME"
+# creator added by default, which is usually not desirable
+cf unset-org-role "$ADMIN" "$ORG_NAME" OrgManager
+cf set-org-role "$MANAGER" "$ORG_NAME" OrgManager
 
 # Step 3: Create the spaces
-cf create-space -o "$ORG_NAME" dev
-cf create-space -o "$ORG_NAME" staging
-cf create-space -o "$ORG_NAME" prod
+declare -a spaces=("dev" "staging" "prod")
+for SPACE in "${spaces[@]}"
+do
+  cf create-space -o "$ORG_NAME" "$SPACE"
+
+  # creator added by default - undo
+  cf unset-space-role "$ADMIN" "$ORG_NAME" "$SPACE" SpaceManager
+  cf unset-space-role "$ADMIN" "$ORG_NAME" "$SPACE" SpaceDeveloper
+
+  cf set-space-role "$MANAGER" "$ORG_NAME" "$SPACE" SpaceDeveloper
+done


### PR DESCRIPTION
The "manager" (meaning the technical lead) for a new deployment will probably want to be an OrgManager and SpaceDeveloper on each of the spaces, so this will now happen as part of the org creation.

/cc @datn @berndverst @jcscottiii 