### PR TITLE
Send uaa invite without emailing user directly.

### DIFF
--- a/send-uaa-invite.sh
+++ b/send-uaa-invite.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+if [ "$#" -lt 1 ]; then
+  printf "Usage:\n\n\t$./send-uaa-invite.sh <USER_EMAIL>"
+  exit 1
+fi
+
+redirect_uri=https://account.fr.cloud.gov/oauth/login
+fugacious_uri=https://fugacious.18f.gov
+
+resp=$(uaac curl -X POST "/invite_users?redirect_uri=${redirect_uri}" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg email $1 '{emails: [$email]}')")
+
+link=$(echo ${resp#*RESPONSE BODY:} | jq -r '.new_invites[0].inviteLink')
+
+fug=$(curl -i ${fugacious_uri}/m \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "$(jq -n --arg body ${link} '{message: {body: $body, hours: 24, max_views: 2}}')" \
+  | grep Location \
+  | awk '{print $2}')
+
+echo "Created ephemeral invite link at: ${fug}"


### PR DESCRIPTION
Necessary when user's agency spiders their email and opens links, which
can consume the normal invite link.