### PR TITLE
simple app to dump EOLs for installed buildpacks

### DIFF
--- a/buildpack-eol/buildpack-eol.go
+++ b/buildpack-eol/buildpack-eol.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v2"
+)
+
+// parse and sort the buildpack manifest yaml
+type dependencyDeprecationDate struct {
+		Date    string
+		Name    string
+		Version string `yaml:"version_line"`
+}
+
+type dependencyDeprecationDates []dependencyDeprecationDate
+
+func (slice dependencyDeprecationDates) Len() int {
+	return len(slice)
+}
+
+func (slice dependencyDeprecationDates) Less(i, j int) bool {
+	return slice[i].Date < slice[j].Date;
+}
+
+func (slice dependencyDeprecationDates) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+type buildpackManifest struct {
+	DependencyDeprecationDates dependencyDeprecationDates `yaml:"dependency_deprecation_dates"`
+}
+
+
+func main() {
+	var wg sync.WaitGroup
+
+	// git a list of buildpacks the janky way
+	out, err := exec.Command("cf", "buildpacks").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//parse out the name of the buildpack and the version
+	r, _ := regexp.Compile(`^(.+?) .+(v\d+.*)\.zip$`)
+	scanner := bufio.NewScanner(bytes.NewBuffer(out))
+	for scanner.Scan() {
+		buildpack := r.FindSubmatch(scanner.Bytes())
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			if len(buildpack) == 0 {
+				return
+			}
+
+			// grab the manifest from github
+			repo := strings.Replace(string(buildpack[1]), "_", "-", -1)
+			version := string(buildpack[2])
+			resp, err := http.Get("https://raw.githubusercontent.com/cloudfoundry/" + repo + "/" + version + "/manifest.yml")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			defer resp.Body.Close()
+			yamldata, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// parse the yaml
+			manifest := buildpackManifest{}
+
+			err = yaml.Unmarshal(yamldata, &manifest)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// if we have info, print it sorted by date
+			if len(manifest.DependencyDeprecationDates) == 0 {
+				return
+			}
+
+			sort.Sort(manifest.DependencyDeprecationDates)
+
+			fmt.Printf("%s %s\n", repo, version)
+			for _, item := range manifest.DependencyDeprecationDates {
+				fmt.Printf("\t%s - %s %s\n", item.Date, item.Name, item.Version)
+			}
+
+		}()
+
+	}
+
+	wg.Wait()
+}
+


### PR DESCRIPTION
	$ go install github.com/18F/cg-scripts/buildpack-eol && $GOPATH/bin/buildpack-eol
	python-buildpack v1.5.16
		2017-09-29 - python 3.3
		2019-03-16 - python 3.4
		2020-01-01 - python 2.7
		2020-09-13 - python 3.5
		2021-12-23 - python 3.6
	nodejs-buildpack v1.5.30
		2017-06-30 - node 7
		2018-04-01 - node 4
		2019-04-18 - node 6
	ruby-buildpack v1.6.35
	php-buildpack v4.3.29
		2016-12-31 - jruby 1.7
		2017-04-26 - nginx 1.10
		2018-04-01 - node 4
		2018-12-03 - php 7.0
		2020-10-01 - openjdk1.8-latest 1.8
		2018-12-31 - php 5.6
		2019-05-18 - newrelic 6.3.0.161
		2019-12-01 - php 7.1
	go-buildpack v1.7.19
		2017-02-16 - go 1.6
	dotnet-core-buildpack v1.0.13
		2019-04-18 - node 6
