### PR TITLE
Add simple parser for XML ZAP report for cross ref to POAM

### DIFF
--- a/parse-owasp-zap-xml.py
+++ b/parse-owasp-zap-xml.py
@@ -1,0 +1,26 @@
+import xml.etree.ElementTree as etree
+import sys
+
+if len(sys.argv) == 1:
+    print('please provide a path to an XML ZAP report')
+    sys.exit(-1)
+filename = sys.argv[1]
+
+tree = etree.parse(filename)
+root = tree.getroot()
+vulnids = {}
+for site in tree.findall('site'):
+    sitename = site.attrib['name']
+    if sitename.find('cloud.gov') != -1:
+        for alert in site.findall('.//alertitem'):
+            id = '{}, CWE id {}, WASC id {}'.format(alert.find('name').text,
+                                                    alert.find('cweid').text,
+                                                    alert.find('wascid').text)
+            sites = vulnids.get(id, [])
+            sites.append(sitename)
+            vulnids[id] = sites
+
+for key in vulnids:
+    print(key)
+    for site in vulnids[key]:
+        print('\t{}'.format(site))


### PR DESCRIPTION
This makes sure that we've stripped anything that doesn't match cloud.gov (like google analytics bits) that may get picked up in the scan spidering process.

example output:
```
SQL Injection, CWE id 89, WASC id 19
	https://foo.cloud.gov
	https://bar.cloud.gov
X-Frame-Options Header Not Set, CWE id 16, WASC id 15
	https://bar.cloud.gov
```

POAM sheet should contain the CWE and WASC ids as `Weakness Reference Identifiers` from previous ZAP reports for cross reference.

/cc @brittag 