### PR TITLE
Obfuscate the quota name + delay fly check

### DIFF
--- a/cf-create-org.sh
+++ b/cf-create-org.sh
@@ -16,14 +16,6 @@ MANAGER=$6
 
 MEMORY="${7:-4G}"
 
-CI_URL="${CI_URL:-"https://ci.fr.cloud.gov"}"
-FLY_TARGET=$(fly targets | grep "${CI_URL}" | head -n 1 | awk '{print $1}')
-
-if ! fly --target "${FLY_TARGET}" workers > /dev/null; then
-  echo "Not logged in to concourse"
-  exit 1
-fi
-
 if ! [[ $AGENCY_NAME =~ ^[a-zA-Z0-9]+$ ]]; then
   echo "AGENCY_NAME must contain only letters and numbers."
   exit 1
@@ -58,23 +50,15 @@ ORG_NAME=$(echo "$ORG_NAME" | awk '{print tolower($0)}')
 NUMBER_OF_ROUTES=20
 NUMBER_OF_SERVICES=20
 
-COUNTER=1
-while true
-do
-    QUOTA_NAME="${QUOTA_NAME_BASE}-$(printf "%02d" "${COUNTER}")"
+# Add the date down to the second in order to avoid collisions for identical inputs
+QUOTA_NAME="${QUOTA_NAME_BASE}-$(date '+%Y%m%d-%H:%M:%S')"
 
-    if cf quota "$QUOTA_NAME" &> /dev/null; then
-        echo "Quota name ${QUOTA_NAME} already exists."
-        echo "Auto-incrementing quota name."
-        ((COUNTER++))
-    else
-        break
-    fi
-done
+# Hash the name to obfuscate the origin of the quota from snooping users
+HASHED_QUOTA_NAME=$(md5 -qs $QUOTA_NAME)
 
 # Step 0: Confirm the inputs.
 # http://stackoverflow.com/a/226724/358804
-printf "Create the following?\n\nQuota: $QUOTA_NAME\nOrg: $ORG_NAME\n\n"
+printf "Create the following?\n\nQuota: $HASHED_QUOTA_NAME\nOrg: $ORG_NAME\n\n"
 select yn in "Yes" "No"; do
   case $yn in
     Yes ) break;;
@@ -82,18 +66,27 @@ select yn in "Yes" "No"; do
   esac
 done
 
-# Step 1: Create the quota
-cf create-quota "$QUOTA_NAME" -m "$MEMORY" -r "$NUMBER_OF_ROUTES" -s "$NUMBER_OF_SERVICES" --allow-paid-service-plans
+# Step 1: Check that we're logged into Concourse
+CI_URL="${CI_URL:-"https://ci.fr.cloud.gov"}"
+FLY_TARGET=$(fly targets | grep "${CI_URL}" | head -n 1 | awk '{print $1}')
+
+if ! fly --target "${FLY_TARGET}" workers > /dev/null; then
+  echo "Not logged in to concourse"
+  exit 1
+fi
+
+# Step 2: Create the quota
+cf create-quota "$HASHED_QUOTA_NAME" -m "$MEMORY" -r "$NUMBER_OF_ROUTES" -s "$NUMBER_OF_SERVICES" --allow-paid-service-plans
 
 ADMIN=$(cf target | grep -i user | awk '{print $2}')
 
-# Step 2: Create the org
-cf create-org "$ORG_NAME" -q "$QUOTA_NAME"
+# Step 3: Create the org
+cf create-org "$ORG_NAME" -q "$HASHED_QUOTA_NAME"
 # creator added by default, which is usually not desirable
 cf unset-org-role "$ADMIN" "$ORG_NAME" OrgManager
 cf set-org-role "$MANAGER" "$ORG_NAME" OrgManager
 
-# Step 3: Create the spaces
+# Step 4: Create the spaces
 declare -a spaces=("dev" "staging" "prod")
 for SPACE in "${spaces[@]}"
 do


### PR DESCRIPTION
* To avoid quotas revealing info about other customers in the system, we create it under a hashed name; the relationship between orgs and quotas is what we care about, not the quota names!
* To make testing easier, don't check that we're logged into Fly until we're actually ready to go through with it!