### PR TITLE
Add CredHub environment setup from Slack

### DIFF
--- a/set-credhub-env.sh
+++ b/set-credhub-env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -lt 1 ]
+then
+  echo "Usage:"
+  echo "    ./set-credhub-env.sh <BOSH_DEPLOYMENT_NAME>"
+  echo "example: ./set-credhub-env.sh developmentbosh"
+  exit 99
+fi
+
+deployment_name=$(bosh deployments | grep -o "${1}")
+
+if [ "$?" -eq 0 ]
+then
+  echo "setting up CredHub environment for ${deployment_name}"
+  export CREDHUB_CLIENT='credhub-admin'
+  export CREDHUB_SECRET="$(
+    bosh -d developmentbosh manifest |\
+    spruce json |\
+    jq -r '.instance_groups[].jobs[] | select( .name == "uaa") | .properties.uaa.clients["credhub-admin"].secret'
+  )"
+  export CREDHUB_CA_CERT=$BOSH_CA_CERT
+  export CREDHUB_SERVER="$(
+    bosh -d developmentbosh manifest |\
+    spruce json |\
+    jq -r '.instance_groups[].properties.director.config_server.url'
+  )"
+fi


### PR DESCRIPTION
I'm not sure of a better way to do this. But I think it's fine to keep it in cg-scripts as we include these in every jump box.

:eyes:
https://gsa-tts.slack.com/archives/C0ENP71UG/p1531336816000371