### PR TITLE
Add network.admin scope for container networking

### DIFF
--- a/make-cf-admin.sh
+++ b/make-cf-admin.sh
@@ -31,7 +31,7 @@ if ! hash uaac 2>/dev/null; then
   gem install cf-uaac
 fi
 
-declare -a admin_groups=("cloud_controller.admin" "uaa.admin" "scim.read" "scim.write" "admin_ui.admin")
+declare -a admin_groups=("cloud_controller.admin" "uaa.admin" "scim.read" "scim.write" "admin_ui.admin" "network.admin")
 if $REMOVE; then
   for group in ${admin_groups[@]}
   do


### PR DESCRIPTION
See docs here;
https://docs.cloudfoundry.org/devguide/deploy-apps/cf-networking.html#grant

See error message from trying this without the scopes;
```
$ cf add-network-policy hw-py --destination-app hw-go
Adding network policy to app hw-py in org sandbox-gsa / space roger.ruiz as roger.ruiz@gsa.gov...
provided scopes [cloud_controller.read password.write cloud_controller.write openid scim.write scim.read cloud_controller.admin uaa.user] do not include allowed scopes [network.admin network.write]
FAILED
```