### PR TITLE
use yaml safe_load

### DIFF
--- a/cf-get-recent-users.py
+++ b/cf-get-recent-users.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     try:
-        check = yaml.load(subprocess.check_output(
+        check = yaml.safe_load(subprocess.check_output(
             [
                 'uaac',
                 'users',
@@ -36,7 +36,7 @@ if __name__ == '__main__':
             ]
         ))
         total = check['totalresults']
-        data = yaml.load(subprocess.check_output(
+        data = yaml.safe_load(subprocess.check_output(
             [
                 'uaac',
                 'users',


### PR DESCRIPTION
fixes #95 
replaces #94 

YAML is _finally_ pushing people to `safe_load` instead of `load`, so we need to call `safe_load` instead.