### PR TITLE
Lowercase the totp username for reset

### DIFF
--- a/reset-totp.sh
+++ b/reset-totp.sh
@@ -9,7 +9,8 @@ if [ "$#" -ne 2 ]; then
 fi
 
 deployment=$1
-totp_username=$2
+# Username is case-sensitive - make it lower-case
+totp_username=$(echo $2 | tr '[A-Z]' '[a-z]')
 
 manifest=$(mktemp)
 bosh -d ${deployment} manifest > "${manifest}"


### PR DESCRIPTION
The TOTP reset is case-sensitive, so  this makes it so the script forces input to lowercase.