### PR TITLE
[WIP] Useful scripts for user reset and pipeline updates

### DIFF
--- a/strip-user-org-and-space-roles.sh
+++ b/strip-user-org-and-space-roles.sh
@@ -1,22 +1,42 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 
-# User input
-# cmd.sh USER ORG SPACE
+set -euo pipefail
+shopt -s inherit_errexit
 
-USER="$1"
-ORG="$2"
-ORGROLE="OrgManager"
+main() {
+  [[ $# -eq 3 ]] || usage "Expected three arguments, got $#"
 
-cf org-users $ORG
-cf unset-org-role $USER $ORG $ORGROLE
+  local user="$1"
+  local org="$2"
+  local space="$3"
 
-SPACE="$3"
-SPACEROLE="SpaceManager"
+  cf unset-org-role "$user" "$org" OrgManager
 
-cf space-users $ORG $SPACE
+  cf space-users "$org" "$space"
 
-cf unset-space-role $USER $ORG $SPACE $SPACEROLE
-SPACEROLE="SpaceDeveloper"
-cf unset-space-role $USER $ORG $SPACE $SPACEROLE
-SPACEROLE="SpaceAuditor"
-cf space-users $ORG $SPACE
+  for space_role in SpaceManager SpaceDeveloper SpaceAuditor; do
+    cf unset-space-role "$user" "$org" "$space" "$space_role"
+  done
+
+  echo "Org users:"
+  cf org-users "$org"
+
+  echo "Space users:"
+  cf space-users "$org" "$space"
+}
+
+usage() {
+  [[ $# -gt 0 ]] && echo "ERROR: $*"
+  cat <<EOF
+  USAGE: $(basename "$0") USER ORG SPACE
+
+  Removes org and space roles for user.
+
+  Examples:
+
+    $(basename "$0") bob accounting dev
+EOF
+  exit 1
+}
+
+main "$@"

--- a/strip-user-org-and-space-roles.sh
+++ b/strip-user-org-and-space-roles.sh
@@ -11,9 +11,6 @@ main() {
   local space="$3"
 
   cf unset-org-role "$user" "$org" OrgManager
-
-  cf space-users "$org" "$space"
-
   for space_role in SpaceManager SpaceDeveloper SpaceAuditor; do
     cf unset-space-role "$user" "$org" "$space" "$space_role"
   done

--- a/strip-user-org-and-space-roles.sh
+++ b/strip-user-org-and-space-roles.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -ex
+
+# User input
+# cmd.sh USER ORG SPACE
+
+USER="$1"
+ORG="$2"
+ORGROLE="OrgManager"
+
+cf org-users $ORG
+cf unset-org-role $USER $ORG $ORGROLE
+
+SPACE="$3"
+SPACEROLE="SpaceManager"
+
+cf space-users $ORG $SPACE
+
+cf unset-space-role $USER $ORG $SPACE $SPACEROLE
+SPACEROLE="SpaceDeveloper"
+cf unset-space-role $USER $ORG $SPACE $SPACEROLE
+SPACEROLE="SpaceAuditor"
+cf space-users $ORG $SPACE

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+# User input or guess keyword
+if [[ -z $1 ]]
+    then
+        KEY=$(pwd | awk -F/ '{print $NF}')
+    else
+        KEY="$1"
+fi
+# verify the pipeline name looks good
+PIPELINE=$(fly -t fr pipelines | grep "${KEY}" | awk '{print $1}')
+echo "Pipeline selected:" "${PIPELINE}"
+
+# Do the next block
+CFG=$(aws s3 ls s3://concourse-credentials | grep "${KEY}" | awk '{print $4}')
+echo "Found config file:" "${CFG}"
+aws s3 cp "s3://concourse-credentials/${CFG}" .
+
+# Save for later just in case
+BACKUP="$(date +"%Y%m%d")_${PIPELINE}.yml"
+fly -t fr gp -p "${PIPELINE}" > "${BACKUP}"
+fly validate-pipeline -c pipeline.yml -l "${CFG}"
+# Make sure it says "looks good"
+
+echo "If the above command says 'looks good', review and reconcile changes:"
+echo "fly -t fr sp -p ${PIPELINE} --config pipeline.yml -l ${CFG}"
+
+echo "IF you changed the config file, update the canonical creds:"
+echo "aws s3 cp --sse AES256 ${CFG} s3://concourse-credentials/${CFG}"
+
+echo "Original pipeline saved to ${BACKUP} - DO NOT COMMIT THIS FILE"

--- a/update-pipeline.sh
+++ b/update-pipeline.sh
@@ -1,30 +1,77 @@
-#!/bin/bash -ex
-# User input or guess keyword
-if [[ -z $1 ]]
-    then
-        KEY=$(pwd | awk -F/ '{print $NF}')
-    else
-        KEY="$1"
-fi
-# verify the pipeline name looks good
-PIPELINE=$(fly -t fr pipelines | grep "${KEY}" | awk '{print $1}')
-echo "Pipeline selected:" "${PIPELINE}"
+#!/usr/bin/env bash
 
-# Do the next block
-CFG=$(aws s3 ls s3://concourse-credentials | grep "${KEY}" | awk '{print $4}')
-echo "Found config file:" "${CFG}"
-aws s3 cp "s3://concourse-credentials/${CFG}" .
+set -euo pipefail
+shopt -s inherit_errexit
 
-# Save for later just in case
-BACKUP="$(date +"%Y%m%d")_${PIPELINE}.yml"
-fly -t fr gp -p "${PIPELINE}" > "${BACKUP}"
-fly validate-pipeline -c pipeline.yml -l "${CFG}"
-# Make sure it says "looks good"
+main() {
+  [[ "${BASH_VERSINFO:-0}" -ge 5 ]]     || usage "This script must be run with Bash 5.x"
+  [[ $# -ge 2 && $# -le 3 ]]            || usage "Expected two or three arguments, received $#"
+  [[ -v CONCOURSE_CREDENTIALS_BUCKET ]] || usage "Expected \$CONCOURSE_CREDENTIALS_BUCKET to be set"
 
-echo "If the above command says 'looks good', review and reconcile changes:"
-echo "fly -t fr sp -p ${PIPELINE} --config pipeline.yml -l ${CFG}"
+  FLY_TARGET=$1
+  PIPELINE_FILE=$2
+  if [[ -v $3 ]]; then
+    PIPELINE="$3"
+  else
+    PIPELINE=$(basename "$GIT_ROOT")
+  fi
 
-echo "IF you changed the config file, update the canonical creds:"
-echo "aws s3 cp --sse AES256 ${CFG} s3://concourse-credentials/${CFG}"
+  GIT_ROOT=$(git rev-parse --show-toplevel)
+  SECRETS_DIR="$GIT_ROOT/do-not-commit"
+  SECRETS_FILE="$SECRETS_DIR/$PIPELINE.yml"
 
-echo "Original pipeline saved to ${BACKUP} - DO NOT COMMIT THIS FILE"
+  ci get-pipelines "$PIPELINE" || usage "Cannot determine pipeline name (guessed $PIPELINE)"
+
+  mkdir "$SECRETS_DIR"
+  aws s3 cp "$CONCOURSE_CREDENTIALS_BUCKET/$PIPELINE.yml" "$SECRETS_FILE"
+
+  ci get-pipeline -p "$PIPELINE" > "$SECRETS_DIR/pipeline-backup-$(date +"%Y%m%d").yml"
+
+  if ci validate-pipeline -c "$PIPELINE_FILE" -l "$SECRETS_FILE" > /dev/null; then
+    ci set-pipeline -p "$PIPELINE" --config "$PIPELINE_FILE" -l "$SECRETS_FILE"
+  fi
+  echo "If you change the $SECRETS_FILE file, update the canonical creds:"
+  echo
+  echo "aws s3 cp --sse AES256 $SECRETS_FILE $CONCOURSE_CREDENTIALS_BUCKET/$PIPELINE.yml"
+}
+
+ci() {
+  fly -t "$FLY_TARGET" "$@";
+}
+
+usage() {
+  [[ $# -gt 0 ]] && echo "  ERROR: $*"
+  cat <<EOF
+  USAGE: $(basename "$0") fly-target pipeline-file [pipeline-name]
+
+  This script updates the given pipeline.  In particular, it:
+
+  1. Downloads the secrets file from S3
+  2. Backs up the existing pipeline definition locally
+  3. Validates the new pipeline file
+  4. Uploads the pipeline to concourse
+
+  It requires that the name of the bucket holding the secret credentials is set
+  in the \$CONCOURSE_CREDENTIALS_BUCKET environment variable.
+
+  If you omit pipeline-name, then the name of the root git directory is used as
+  a best guess.
+
+  This script assumes that "do-not-commit" is configured in the project
+  .gitignore (or your global excludesfile).  See the documentation on
+  "core.excludesfile" for more info:
+
+    https://help.github.com/en/github/using-git/ignoring-files
+
+  Examples:
+
+    export CONCOURSE_CREDENTIALS_BUCKET=s3://mysekrits
+
+    $(basename "$0") concourse ./ci/pipeline.yml
+
+    $(basename "$0") concourse pipeline.yml deploy-foo
+EOF
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a script for updating a pipeline config automatically with prompts of what to do next
  - The `KEY` isn't always correctly found, so the `awk` command should get refined
- Adds a script to strip user roles
  - I had grand plans to use the `cf curl` api to get all the user's org and space roles to iterate through them, but this version just takes what's specified on the command line

## security considerations
None, these incorporate the procedures already on cloud.gov that operators follow.
