### PR TITLE
Add script to work with secrets files in s3

### DIFF
--- a/s3-secret
+++ b/s3-secret
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+main() {
+  [[ $# -ge 2 ]] || usage "Expected at least two arguments, got $#"
+  [[ -v SECRETS_BUCKET ]] || usage "Must set $SECRETS_BUCKET variable first."
+  command=$1; shift
+  case $command in
+    upload)
+      upload "$@"
+      ;;
+
+    download)
+      download "$@"
+      ;;
+
+    *)
+      usage "Unknown command: $command"
+      ;;
+  esac
+}
+
+upload() {
+  [[ $# -ge 1 ]] || usage "Wrong number of arguments to upload"
+  for file in "$@"; do
+    echo "$file"
+    aws s3 cp --only-show-errors --sse=AES256 "$file" "$SECRETS_BUCKET"
+  done
+}
+
+download() {
+  [[ $# -eq 2 ]] || usage "Wrong number of arguments to download"
+
+  file="$1"; shift
+  directory="$1"; shift
+  [[ -d $directory ]] || usage "Destination directory $directory doesn't exist"
+
+  case $file in
+    all)
+      aws s3 cp --only-show-errors --recursive "$SECRETS_BUCKET" "$directory"
+      ;;
+    *)
+      aws s3 cp --only-show-errors "$SECRETS_BUCKET/$file" "$directory/$file"
+      ;;
+  esac
+}
+
+usage() {
+  [[ $# -gt 0 ]] && (echo "ERROR: $*"; echo)
+  cat <<EOF
+USAGE:
+
+  $(basename "$0") upload file1 file2 ...
+
+  $(basename "$0") download remote_file directory
+
+  $(basename "$0") download all directory
+
+Uploads and downloads cloud.gov secrets to/from the S3 buckets.  "download all"
+will get all files, recursively.  Requires SECRETS_BUCKET to be set.
+
+Examples:
+
+  $(basename "$0") upload path/to/secrets.yml
+  $(basename "$0") download secret.yml secrets_dir
+  $(basename "$0") download all secrets_dir
+EOF
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Changes proposed in this pull request:

Add script to work with secrets files in s3

## security considerations

Reveals the fact that we keep secrets files in S3, but that's already public knowledge.