### PR TITLE
Adding script to bulk reset aide

### DIFF
--- a/bosh/bulk-clear-aide.sh
+++ b/bosh/bulk-clear-aide.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script does a bulk reset of aide across all VMs in all deployments
+
+set -e
+
+for DEPLOYMENTS in $(bosh deps --json | jq -r '.Tables[].Rows[].name')
+do
+    for INSTANCEGROUP in $(bosh -d $DEPLOYMENTS vms --json | jq -r '.Tables[].Rows[].instance' | awk -F'/' '{print $1}' | sort | uniq)
+    do
+        echo "Deployment: $DEPLOYMENTS InstanceGroup: $INSTANCEGROUP"
+        bosh -d $DEPLOYMENTS ssh $INSTANCEGROUP "sudo /var/vcap/jobs/aide/bin/post-deploy; sudo /etc/cron.hourly/run-report"
+    done
+done


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bulk script that finds all deployments on the targeted BOSH director, sorts instance groups, and runs aide reset

## security considerations
n/a