### PR TITLE
Remove space roles before org role

### DIFF
--- a/cloudfoundry/strip-user-org-and-space-roles.sh
+++ b/cloudfoundry/strip-user-org-and-space-roles.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 shopt -s inherit_errexit || true
 
+MAX_SPACE_ROLES=40
+MAX_ORG_ROLES=8
+
 main() {
   [[ $# -eq 2 ]] || usage "Expected two arguments, got $#"
 
@@ -25,7 +28,7 @@ main() {
     local space_guids_csv
     space_guids_csv=$(echo "$SPACE_GUIDS" | paste -sd, -)
     # limit to 20 role lest we have a bug later
-    for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&space_guids=$space_guids_csv&per_page=20" | jq -r '.resources[].guid'); do
+    for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&space_guids=$space_guids_csv&per_page=${MAX_SPACE_ROLES}" | jq -r '.resources[].guid'); do
       echo cf curl -X DELETE "/v3/roles/$role_guid"
       sleep 1
       cf curl -X DELETE "/v3/roles/$role_guid"
@@ -33,7 +36,7 @@ main() {
   fi
 
   # now remove all org-level roles for the user, including organization_user
-  for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&organization_guids=$ORGANIZATION_GUID&per_page=1" | jq -r '.resources[].guid'); do
+  for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&organization_guids=$ORGANIZATION_GUID&per_page=${MAX_ORG_ROLES}" | jq -r '.resources[].guid'); do
     # Let the above role removals propagate (sleep 1 was insufficent)
     sleep 5
     cf curl -X DELETE "/v3/roles/$role_guid"

--- a/cloudfoundry/strip-user-org-and-space-roles.sh
+++ b/cloudfoundry/strip-user-org-and-space-roles.sh
@@ -18,8 +18,24 @@ main() {
 
   ORGANIZATION_GUID=$(cf org "$org" --guid)
 
-  # get all user roles for the org, including organization_user
-  for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&organization_guids=$ORGANIZATION_GUID&per_page=5000" | jq -r '.resources[].guid'); do
+  # get all space guids belonging to the org
+  SPACE_GUIDS=$(cf curl "/v3/spaces?organization_guids=$ORGANIZATION_GUID" | jq -r '.resources[].guid')
+
+  if [[ -n "$SPACE_GUIDS" ]]; then
+    local space_guids_csv
+    space_guids_csv=$(echo "$SPACE_GUIDS" | paste -sd, -)
+    # limit to 20 role lest we have a bug later
+    for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&space_guids=$space_guids_csv&per_page=20" | jq -r '.resources[].guid'); do
+      echo cf curl -X DELETE "/v3/roles/$role_guid"
+      sleep 1
+      cf curl -X DELETE "/v3/roles/$role_guid"
+    done
+  fi
+
+  # now remove all org-level roles for the user, including organization_user
+  for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&organization_guids=$ORGANIZATION_GUID&per_page=1" | jq -r '.resources[].guid'); do
+    # Let the above role removals propagate (sleep 1 was insufficent)
+    sleep 5
     cf curl -X DELETE "/v3/roles/$role_guid"
   done
 }

--- a/cloudfoundry/strip-user-org-and-space-roles.sh
+++ b/cloudfoundry/strip-user-org-and-space-roles.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 shopt -s inherit_errexit || true
 
-MAX_SPACE_ROLES=40
-MAX_ORG_ROLES=8
+MAX_SPACE_ROLES=100
+MAX_ORG_ROLES=20
 
 main() {
   [[ $# -eq 2 ]] || usage "Expected two arguments, got $#"
@@ -19,7 +19,10 @@ main() {
     exit 1
   fi
 
-  ORGANIZATION_GUID=$(cf org "$org" --guid)
+  if ! ORGANIZATION_GUID=$(cf org "$org" --guid); then
+    echo "no org found for $org. Either it doesn't exist or something else went wrong"
+    exit 1
+  fi
 
   # get all space guids belonging to the org
   SPACE_GUIDS=$(cf curl "/v3/spaces?organization_guids=$ORGANIZATION_GUID" | jq -r '.resources[].guid')
@@ -27,16 +30,16 @@ main() {
   if [[ -n "$SPACE_GUIDS" ]]; then
     local space_guids_csv
     space_guids_csv=$(echo "$SPACE_GUIDS" | paste -sd, -)
-    # limit to 20 role lest we have a bug later
-    for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&space_guids=$space_guids_csv&per_page=${MAX_SPACE_ROLES}" | jq -r '.resources[].guid'); do
-      echo cf curl -X DELETE "/v3/roles/$role_guid"
-      sleep 1
+
+    for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&space_guids=$space_guids_csv&per_page=$MAX_SPACE_ROLES" | jq -r '.resources[].guid'); do
+      echo removing space role with: cf curl -X DELETE "/v3/roles/$role_guid"
       cf curl -X DELETE "/v3/roles/$role_guid"
     done
   fi
 
   # now remove all org-level roles for the user, including organization_user
-  for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&organization_guids=$ORGANIZATION_GUID&per_page=${MAX_ORG_ROLES}" | jq -r '.resources[].guid'); do
+  for role_guid in $(cf curl "/v3/roles?user_guids=$USER_GUID&organization_guids=$ORGANIZATION_GUID&per_page=$MAX_ORG_ROLES" | jq -r '.resources[].guid'); do
+    echo removing org role with: cf curl -X DELETE "/v3/roles/$role_guid"
     # Let the above role removals propagate (sleep 1 was insufficent)
     sleep 5
     cf curl -X DELETE "/v3/roles/$role_guid"

--- a/cloudfoundry/strip-user-org-and-space-roles.sh
+++ b/cloudfoundry/strip-user-org-and-space-roles.sh
@@ -43,13 +43,13 @@ main() {
 usage() {
   [[ $# -gt 0 ]] && echo "ERROR: $*"
   cat <<EOF
-  USAGE: $(basename "$0") USER ORG SPACE
+  USAGE: $(basename "$0") USER ORG
 
   Removes org and space roles for user.
 
   Examples:
 
-    $(basename "$0") bob accounting dev
+    $(basename "$0") bob@cfo.gov accounting
 EOF
   exit 1
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix: 
```
{"errors":[{"detail":"Cannot delete organization_user role while user has roles in spaces in that organization.","title":"CF-UnprocessableEntity","code":10008}]}
```
- Update usage
- Add a sleep before removing org roles (it failed the first time probably because a change hadn't propagated)
- Echo the commands to provide feedback on what's happening
- 

## security considerations

Safe: strips user roles, with some constraints to prevent out-of-bound loops
